### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@master
         with:
-          ruby-version: '3.2.2' # Not needed with a .ruby-version file
+          ruby-version: '3.3.0' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v3.0.0
 
   # Deployment job
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3.0.0
+        uses: actions/deploy-pages@v4.0.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 4.3.2'
+gem 'jekyll', '~> 4.3.3'
 
 group :jekyll_plugins do
   gem 'jekyll-timeago', '~> 0.15.0'

--- a/forty_jekyll_theme.gemspec
+++ b/forty_jekyll_theme.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
 
-  spec.add_development_dependency "jekyll", "~> 4.3.2"
-  spec.add_development_dependency "bundler", "~> 2.4.22"
+  spec.add_development_dependency "jekyll", "~> 4.3.3"
+  spec.add_development_dependency "bundler", "~> 2.5.3"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "npm": "^10.2.4"
+        "npm": "^10.2.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.40.1",
-        "@types/node": "^20.10.3"
+        "@types/node": "^20.10.5"
       }
     },
     "node_modules/@playwright/test": {
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
-      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.4.tgz",
-      "integrity": "sha512-umEuYneVEYO9KoEEI8n2sSGmNQeqco/3BSeacRlqIkCzw4E7XGtYSWMeJobxzr6hZ2n9cM+u5TsMTcC5bAgoWA==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.5.tgz",
+      "integrity": "sha512-lXdZ7titEN8CH5YJk9C/aYRU9JeDxQ4d8rwIIDsvH3SMjLjHTukB2CFstMiB30zXs4vCrPN2WH6cDq1yHBeJAw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -143,7 +143,7 @@
         "@sigstore/tuf": "^2.2.0",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.0",
+        "cacache": "^18.0.1",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
@@ -157,7 +157,7 @@
         "ini": "^4.1.1",
         "init-package-json": "^6.0.0",
         "is-cidr": "^5.0.3",
-        "json-parse-even-better-errors": "^3.0.0",
+        "json-parse-even-better-errors": "^3.0.1",
         "libnpmaccess": "^8.0.1",
         "libnpmdiff": "^6.0.3",
         "libnpmexec": "^7.0.4",
@@ -186,7 +186,7 @@
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.4",
+        "pacote": "^17.0.5",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
@@ -213,21 +213,37 @@
       }
     },
     "node_modules/npm/node_modules/@colors/colors": {
+      "version": "1.5.0",
       "inBundle": true,
-      "optional": true
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
-      "inBundle": true
+      "version": "8.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -243,23 +259,102 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "inBundle": true
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "inBundle": true
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "inBundle": true
+      "version": "7.2.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^3.1.0",
+        "@npmcli/installed-package-contents": "^2.0.2",
+        "@npmcli/map-workspaces": "^3.0.2",
+        "@npmcli/metavuln-calculator": "^7.0.0",
+        "@npmcli/name-from-folder": "^2.0.0",
+        "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^5.0.0",
+        "@npmcli/query": "^3.0.1",
+        "@npmcli/run-script": "^7.0.2",
+        "bin-links": "^4.0.1",
+        "cacache": "^18.0.0",
+        "common-ancestor-path": "^1.0.1",
+        "hosted-git-info": "^7.0.1",
+        "json-parse-even-better-errors": "^3.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "minimatch": "^9.0.0",
+        "nopt": "^7.0.0",
+        "npm-install-checks": "^6.2.0",
+        "npm-package-arg": "^11.0.1",
+        "npm-pick-manifest": "^9.0.0",
+        "npm-registry-fetch": "^16.0.0",
+        "npmlog": "^7.0.1",
+        "pacote": "^17.0.4",
+        "parse-conflict-json": "^3.0.0",
+        "proc-log": "^3.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^1.0.2",
+        "read-package-json-fast": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^10.0.5",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^3.0.1"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "inBundle": true
+      "version": "8.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^3.0.2",
+        "ci-info": "^4.0.0",
+        "ini": "^4.1.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "read-package-json-fast": "^3.0.2",
+        "semver": "^7.3.5",
+        "walk-up-path": "^3.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "inBundle": true
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-styles": "^4.3.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -273,19 +368,66 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "inBundle": true
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "inBundle": true
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^7.0.0",
+        "lru-cache": "^10.0.1",
+        "npm-pick-manifest": "^9.0.0",
+        "proc-log": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "inBundle": true
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "lib/index.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "inBundle": true
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^2.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
+        "read-package-json-fast": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "7.0.0",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^18.0.0",
@@ -299,6 +441,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
+      "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -306,19 +449,43 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "3.0.0",
+      "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "inBundle": true
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^5.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^7.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^6.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "inBundle": true
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.1",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "postcss-selector-parser": "^6.0.10"
@@ -328,26 +495,76 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "inBundle": true
+      "version": "7.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/promise-spawn": "^7.0.0",
+        "node-gyp": "^10.0.0",
+        "read-package-json-fast": "^3.0.0",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
       "inBundle": true,
-      "optional": true
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "inBundle": true
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "inBundle": true
+      "version": "0.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "inBundle": true
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/protobuf-specs": "^0.2.1",
+        "make-fetch-happen": "^13.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "inBundle": true
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.2.1",
+        "tuf-js": "^2.1.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -355,6 +572,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "2.0.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
@@ -385,6 +603,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -418,6 +637,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -474,6 +694,7 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "4.0.3",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^6.0.0",
@@ -533,7 +754,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.0",
+      "version": "18.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -542,7 +763,7 @@
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
         "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
@@ -661,6 +882,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "6.0.2",
+      "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -668,7 +890,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -680,7 +901,6 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -725,6 +945,7 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/console-control-strings": {
@@ -761,6 +982,7 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "inBundle": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -771,6 +993,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.4",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -786,6 +1009,7 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/defaults": {
@@ -814,7 +1038,6 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -1005,6 +1228,7 @@
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -1016,6 +1240,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.2",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -1057,7 +1282,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1110,6 +1335,7 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
@@ -1181,7 +1407,7 @@
       }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1190,6 +1416,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "inBundle": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1214,7 +1441,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.1",
+      "version": "8.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1226,7 +1453,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1245,7 +1472,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.4",
+      "version": "7.0.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1266,7 +1493,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1277,7 +1504,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.0",
+      "version": "10.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1289,7 +1516,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1301,7 +1528,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1315,7 +1542,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1333,7 +1560,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1344,7 +1571,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1356,7 +1583,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1371,12 +1598,9 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.0.2",
+      "version": "10.1.0",
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -1425,25 +1649,14 @@
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
@@ -1664,6 +1877,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "3.0.0",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-normalize-package-bin": "^3.0.0"
@@ -1706,11 +1920,11 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "8.0.0",
+      "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ignore-walk": "^6.0.0"
+        "ignore-walk": "^6.0.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -1796,7 +2010,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.4",
+      "version": "17.0.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1864,6 +2078,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.0.13",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -1891,6 +2106,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "inBundle": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1898,6 +2114,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "1.0.2",
+      "inBundle": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1905,6 +2122,7 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
+      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
@@ -1950,6 +2168,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
+      "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -2105,6 +2324,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -2113,6 +2333,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.7.1",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ip": "^2.0.0",
@@ -2125,6 +2346,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -2198,6 +2420,7 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2210,6 +2433,7 @@
     },
     "node_modules/npm/node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2217,6 +2441,7 @@
     },
     "node_modules/npm/node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2261,6 +2486,7 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2271,6 +2497,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2353,6 +2580,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "2.1.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/models": "2.0.0",
@@ -2387,6 +2615,7 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
@@ -2454,6 +2683,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -2470,6 +2700,7 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2485,6 +2716,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2492,6 +2724,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2505,6 +2738,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2515,10 +2749,12 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "index.js",
   "devDependencies": {
     "@playwright/test": "^1.40.1",
-    "@types/node": "^20.10.3"
+    "@types/node": "^20.10.5"
   },
   "scripts": {},
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "npm": "^10.2.4"
+    "npm": "^10.2.5"
   }
 }


### PR DESCRIPTION
Update Dependencies
• Update ruby-version to 3.3.0
• Update jekyll to 4.3.3
• Update npm to 10.2.5
• Update @types/node to 20.10.5
• Update actions/upload-pages-artifact to 3.0.0
• Update actions/deploy-pages to 4.0.2