### PR TITLE
🚀 Release 1.1.5

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.5' # Not needed with a .ruby-version file
+          ruby-version: '3.3.6' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :jekyll_plugins do
   gem 'jekyll-timeago', '~> 0.15.0'
 end
 
-gem "webrick", "~> 1.8.2"
+gem "webrick", "~> 1.9.0"
 gem 'wdm', '>= 0.2.0'
-gem 'google-protobuf', '4.28.2'
+gem 'google-protobuf', '4.28.3'

--- a/forty_jekyll_theme.gemspec
+++ b/forty_jekyll_theme.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
 
-  spec.add_development_dependency "liquid", "~> 5.5.1"
+  spec.add_development_dependency "liquid", "~> 5.6.0.rc1"
   spec.add_development_dependency "safe_yaml", "~> 1.0.5"
   spec.add_development_dependency "jekyll", "~> 4.3.4"
-  spec.add_development_dependency "bundler", "~> 2.5.22"
+  spec.add_development_dependency "bundler", "~> 2.5.23"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
         "npm": "^10.9.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.48.1",
-        "@types/node": "^22.7.6"
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.9.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
-      "integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.1"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -33,13 +33,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/fsevents": {
@@ -2950,13 +2950,13 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2969,9 +2969,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "akospaha01.github.io",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "[![Deploy Jekyll site to Pages](https://github.com/AkosPaha01/akospaha01.github.io/actions/workflows/jekyll.yml/badge.svg)](https://github.com/AkosPaha01/akospaha01.github.io/actions/workflows/jekyll.yml)",
   "main": "index.js",
   "devDependencies": {
-    "@playwright/test": "^1.48.1",
-    "@types/node": "^22.7.6"
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.9.0"
   },
   "scripts": {},
   "keywords": [],

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -91,6 +91,6 @@ test.describe('Test', async() => {
    const response =  await request.get('../../assets/json/release-output-metadata.json')
    const data = await response.json()
 
-   expect(data.elements[0].versionCode).toBe(393000)
+   expect(data.elements[0].versionCode).toBe(394000)
   });
 })


### PR DESCRIPTION
New Changes:
• Update Bundler to 2.5.23
• Update Google Protobuf to 4.28.3
• Update Liquid to 5.6.0.rc1
• Update Playwright/test to 1.49.0
• Update Ruby to 3.3.6
• Update Types/node to 22.9.0
• Update Webrick to 1.9.0